### PR TITLE
local_file data source

### DIFF
--- a/local/data_source_local_file.go
+++ b/local/data_source_local_file.go
@@ -1,0 +1,43 @@
+package local
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"io/ioutil"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceLocalFile() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceLocalFileRead,
+
+		Schema: map[string]*schema.Schema{
+			"filename": {
+				Type:        schema.TypeString,
+				Description: "Path to the output file",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceLocalFileRead(d *schema.ResourceData, _ interface{}) error {
+	path := d.Get("filename").(string)
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	d.Set("content", string(content))
+
+	checksum := sha1.Sum([]byte(content))
+	d.SetId(hex.EncodeToString(checksum[:]))
+
+	return nil
+}

--- a/local/data_source_local_file_test.go
+++ b/local/data_source_local_file_test.go
@@ -1,0 +1,50 @@
+package local
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestLocalFileDataSource(t *testing.T) {
+	var tests = []struct {
+		content string
+		config  string
+	}{
+		{
+			"This is some content",
+			`
+				resource "local_file" "file" {
+					content  = "This is some content"
+					filename = "local_file"
+				}
+				data "local_file" "file" {
+					filename = "${local_file.file.filename}"
+				}
+			`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			resource.UnitTest(t, resource.TestCase{
+				Providers: testProviders,
+				Steps: []resource.TestStep{
+					{
+						Config: test.config,
+						Check: func(s *terraform.State) error {
+							m := s.RootModule()
+							i := m.Resources["data.local_file.file"].Primary
+							if got, want := i.Attributes["content"], test.content; got != want {
+								return fmt.Errorf("wrong content %q; want %q", got, want)
+							}
+							return nil
+						},
+					},
+				},
+			})
+		})
+	}
+}

--- a/local/provider.go
+++ b/local/provider.go
@@ -11,5 +11,8 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"local_file": resourceLocalFile(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"local_file": dataSourceLocalFile(),
+		},
 	}
 }

--- a/website/docs/d/file.html.md
+++ b/website/docs/d/file.html.md
@@ -1,0 +1,36 @@
+---
+layout: "local"
+page_title: "Local: local_file"
+sidebar_current: "docs-local-datasource-file"
+description: |-
+  Reads a file from the local filesystem.
+---
+
+# local_file
+
+`local_file` reads a file from the local filesystem.
+
+## Example Usage
+
+```hcl
+data "local_file" "foo" {
+    filename = "${path.module}/foo.bar"
+}
+```
+
+## Argument Reference
+
+The following argument is required:
+
+* `filename` - (Required) The path to the file that will be read. The data
+  source will return an error if the file does not exist.
+
+## Attributes Exported
+
+The following attribute is exported:
+
+* `content` - The raw content of the file that was read.
+
+The content of the file must be valid UTF-8 due to Terraform's assumptions
+about string encoding. Files that do not contain UTF-8 text will have invalid
+UTF-8 sequences replaced with the Unicode replacement character.

--- a/website/local.erb
+++ b/website/local.erb
@@ -9,6 +9,15 @@
         <a href="/docs/providers/local/index.html">Local Provider</a>
       </li>
 
+      <li<%= sidebar_current("docs-local-datasource") %>>
+        <a href="#">Data Sources</a>
+        <ul class="nav nav-visible">
+          <li<%= sidebar_current("docs-local-datasource-file") %>>
+            <a href="/docs/providers/local/d/file.html">file</a>
+          </li>
+        </ul>
+      </li>
+
       <li<%= sidebar_current("docs-local-resource") %>>
         <a href="#">Resources</a>
         <ul class="nav nav-visible">


### PR DESCRIPTION
This is the data source analog to the `local_file` resource, allowing files to be read in a way that participates in the dependency graph.

The current behavior of `depends_on` for data sources unfortunately makes this hard to use in practice without creating a "perma-diff", but this is planned to be addressed in core eventually at which point this will provide a good alternative to the `file()` interpolation function when reading files that are generated dynamically during the run, whereas `file()` is intended for reading files that are statically available as
part of the configuration.

For now the documentation does not mention the possibility of using this data source to delay file reading until another resource has been created due to that `depends_on` limitation, but once that is addressed we should update the example here to illustrate that and then change the `file()` function documentation in core to note explicitly that it is for statically-available files only and that this data source should be used instead for files that are created dynamically.