### PR TITLE
Add sensitive_content argument to local_file resource

### DIFF
--- a/local/resource_local_file.go
+++ b/local/resource_local_file.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 
-	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -19,15 +18,17 @@ func resourceLocalFile() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"content": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"sensitive_content"},
 			},
 			"sensitive_content": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  true,
-				Sensitive: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"content"},
 			},
 			"filename": {
 				Type:        schema.TypeString,
@@ -64,26 +65,19 @@ func resourceLocalFileRead(d *schema.ResourceData, _ interface{}) error {
 	return nil
 }
 
-func resourceLocalFileContent(d *schema.ResourceData) (string, string) {
-	content, contentSpecified := d.GetOk("content")
+func resourceLocalFileContent(d *schema.ResourceData) string {
+	content := d.Get("content")
 	sensitiveContent, sensitiveSpecified := d.GetOk("sensitive_content")
-	if (contentSpecified && sensitiveSpecified) || (!contentSpecified && !sensitiveSpecified) {
-		return "", "Exactly one of `content` or `sensitive_content` must be specified"
-	}
 	useContent := content.(string)
 	if sensitiveSpecified {
 		useContent = sensitiveContent.(string)
 	}
 
-	return useContent, ""
+	return useContent
 }
 
 func resourceLocalFileCreate(d *schema.ResourceData, _ interface{}) error {
-	content, errMsg := resourceLocalFileContent(d)
-	if errMsg != "" {
-		return fmt.Errorf(errMsg)
-	}
-
+	content := resourceLocalFileContent(d)
 	destination := d.Get("filename").(string)
 
 	destinationDir := path.Dir(destination)

--- a/local/resource_local_file_test.go
+++ b/local/resource_local_file_test.go
@@ -9,7 +9,6 @@ import (
 
 	r "github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestLocalFile_Basic(t *testing.T) {
@@ -59,28 +58,6 @@ func TestLocalFile_Basic(t *testing.T) {
 					return nil
 				}
 				return errors.New("local_file did not get destroyed")
-			},
-		})
-	}
-}
-
-func TestLocalFile_contentConfigThrowsError(t *testing.T) {
-	configs := []string{`resource "local_file" "file" {
-         content     = "This is some content"
-         sensitive_content     = "This is some sensitive content"
-         filename    = "local_file"
-      }`, `resource "local_file" "file" {
-         filename    = "local_file"
-      }`,
-	}
-	for _, config := range configs {
-		r.UnitTest(t, r.TestCase{
-			Providers: testProviders,
-			Steps: []r.TestStep{
-				{
-					Config:      config,
-					ExpectError: regexp.MustCompile(regexp.QuoteMeta("Exactly one of `content` or `sensitive_content` must be specified")),
-				},
 			},
 		})
 	}

--- a/website/docs/r/file.html.md
+++ b/website/docs/r/file.html.md
@@ -29,9 +29,9 @@ resource "local_file" "foo" {
 
 The following arguments are supported:
 
-* `content` - (Optional) The content of file to create. Either `content` or `sensitive_content` must be set.
+* `content` - (Optional) The content of file to create. Conflicts with `sensitive_content`.
 
-* `sensitive_content` - (Optional) The content of file to create. Will not be displayed in diffs. Either `content` or `sensitive_content` must be set.
+* `sensitive_content` - (Optional) The content of file to create. Will not be displayed in diffs. Conflicts with `content`.
 
 * `filename` - (Required) The path of the file to create.
 

--- a/website/docs/r/file.html.md
+++ b/website/docs/r/file.html.md
@@ -29,7 +29,9 @@ resource "local_file" "foo" {
 
 The following arguments are supported:
 
-* `content` - (Required) The content of file to create.
+* `content` - (Optional) The content of file to create. Either `content` or `sensitive_content` must be set.
+
+* `sensitive_content` - (Optional) The content of file to create. Will not be displayed in diffs. Either `content` or `sensitive_content` must be set.
 
 * `filename` - (Required) The path of the file to create.
 


### PR DESCRIPTION
Diffs for the `local_file` resource include the file content. This can present a problem if the content contains sensitive data. This pull request adds a `sensitive_content` argument to the `local_file` resource, causing the file contents to not be included in diff output. The new argument is mutually exclusive with the existing `content` argument. Exactly one of the two must be present. 

I alternatively considered adding a separate "sensitive_local_file" resource, but adding an attribute to the existing resource seemed more appropriate. 