### PR TITLE
local_file: allow for configurable permissions

### DIFF
--- a/local/resource_local_file.go
+++ b/local/resource_local_file.go
@@ -36,6 +36,20 @@ func resourceLocalFile() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
+			"file_permission": {
+				Type:        schema.TypeInt,
+				Description: "Permissions to set for the output file",
+				Optional:    true,
+				ForceNew:    true,
+				Default:     0777,
+			},
+			"directory_permission": {
+				Type:        schema.TypeInt,
+				Description: "Permissions to set for directories created",
+				Optional:    true,
+				ForceNew:    true,
+				Default:     0777,
+			},
 		},
 	}
 }
@@ -82,12 +96,14 @@ func resourceLocalFileCreate(d *schema.ResourceData, _ interface{}) error {
 
 	destinationDir := path.Dir(destination)
 	if _, err := os.Stat(destinationDir); err != nil {
-		if err := os.MkdirAll(destinationDir, 0777); err != nil {
+		perm := d.Get("directory_permission").(int)
+		if err := os.MkdirAll(destinationDir, os.FileMode(perm)); err != nil {
 			return err
 		}
 	}
 
-	if err := ioutil.WriteFile(destination, []byte(content), 0777); err != nil {
+	perm := d.Get("file_permission").(int)
+	if err := ioutil.WriteFile(destination, []byte(content), os.FileMode(perm)); err != nil {
 		return err
 	}
 

--- a/website/docs/r/file.html.md
+++ b/website/docs/r/file.html.md
@@ -35,5 +35,11 @@ The following arguments are supported:
 
 * `filename` - (Required) The path of the file to create.
 
+* `file_permission` - (Optional) The permission to set for the created file. Expects an an integer and can be specified
+   as an octal. The default value is `0777`.
+
+* `directory_permission` - (Optional) The permission to set for any directories created. Expects an an integer and can
+  be specified as an octal. The default value is `0777`.
+
 Any required parent directories will be created automatically, and any existing
 file with the given name will be overwritten.


### PR DESCRIPTION
Permissions for any created file or directories can now be explicitly
specified if required.

This change preserves the current behavior by defaulting to previously
used `0777` values for both file and directory permissions.

Resolves: #3