### PR TITLE
fix error when writing file with empty content

### DIFF
--- a/local/resource_local_file.go
+++ b/local/resource_local_file.go
@@ -91,8 +91,9 @@ func resourceLocalFileCreate(d *schema.ResourceData, _ interface{}) error {
 		return err
 	}
 
-	checksum := sha1.Sum([]byte(content))
-	d.SetId(hex.EncodeToString(checksum[:]))
+	filenameChecksum := sha1.Sum([]byte(destination))
+	contentChecksum := sha1.Sum([]byte(content))
+	d.SetId(hex.EncodeToString(append(filenameChecksum[:], contentChecksum[:]...)))
 
 	return nil
 }


### PR DESCRIPTION
Fixes #15 

Previously, attempting to write a local file with content of `""` would set the resource `Id` to `""`, since the `Id` is based on a SHA1 of the content. This caused the file to be deleted during the apply step.

The resource `Id` of an empty file is now the SHA1 of the filename concatenated with the SHA1 of the content, so it will never be `""`.